### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/amd64-icu-patch.yml
+++ b/.github/workflows/amd64-icu-patch.yml
@@ -7,7 +7,7 @@ jobs:
         container:
             image: alpine:latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v2.3.4
             - run: apk add bash
             - run: bash qbittorrent-nox-static.sh
             - run: bash qbittorrent-nox-static.sh zlib

--- a/.github/workflows/amd64-icu.yml
+++ b/.github/workflows/amd64-icu.yml
@@ -7,7 +7,7 @@ jobs:
         container:
             image: alpine:latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v2.3.4
             - run: apk add bash
             - run: bash qbittorrent-nox-static.sh
             - run: bash qbittorrent-nox-static.sh zlib

--- a/.github/workflows/amd64-patch.yml
+++ b/.github/workflows/amd64-patch.yml
@@ -7,7 +7,7 @@ jobs:
         container:
             image: alpine:latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v2.3.4
             - run: apk add bash
             - run: bash qbittorrent-nox-static.sh
             - run: bash qbittorrent-nox-static.sh zlib

--- a/.github/workflows/amd64.yml
+++ b/.github/workflows/amd64.yml
@@ -10,7 +10,7 @@ jobs:
     container:
       image: alpine:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - run: apk add bash
         shell: ash {0}
       - run: bash qbittorrent-nox-static.sh

--- a/.github/workflows/arm64-icu-patch.yml
+++ b/.github/workflows/arm64-icu-patch.yml
@@ -5,7 +5,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v2.3.4
             - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             - name: arm64v8 image
               uses: docker://arm64v8/alpine

--- a/.github/workflows/arm64-icu.yml
+++ b/.github/workflows/arm64-icu.yml
@@ -5,7 +5,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v2.3.4
             - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             - name: arm64v8 image
               uses: docker://arm64v8/alpine

--- a/.github/workflows/arm64-patch.yml
+++ b/.github/workflows/arm64-patch.yml
@@ -5,7 +5,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v2.3.4
             - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             - name: arm64v8 image
               uses: docker://arm64v8/alpine

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -5,7 +5,7 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v2.3.4
             - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
             - name: arm64v8 image
               uses: docker://arm64v8/alpine

--- a/.github/workflows/jerry-amd64-icu-patch.yml
+++ b/.github/workflows/jerry-amd64-icu-patch.yml
@@ -7,7 +7,7 @@ jobs:
         container:
             image: alpine:latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v2.3.4
             - run: apk add bash
             - run: bash qbittorrent-nox-static.sh
             - run: bash qbittorrent-nox-static.sh zlib

--- a/.github/workflows/swizzin.yml
+++ b/.github/workflows/swizzin.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - run: sudo apt-get update
       - run: sudo apt-get -y upgrade
       - run: sudo apt-get -y install python git curl

--- a/.github/workflows/update_actions.yml
+++ b/.github/workflows/update_actions.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.SECRET_SECRET }}
@@ -28,5 +28,5 @@ jobs:
           # Do not update these actions (Optional)
           # You need to add JSON array inside a string
           # because GitHub Actions does not yet allow `Lists` as input
-          # ignore: '["actions/checkout@v2", "actions/cache@v2"]'
+          # ignore: '["actions/checkout@v2.3.4", "actions/cache@v2"]'
           ignore: '["docker://arm64v8/alpine"]'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.3.4](https://github.com/actions/checkout/releases/tag/v2.3.4) on 2020-11-03T14:48:49Z
