### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/jerry-amd64-icu-patch.yml
+++ b/.github/workflows/jerry-amd64-icu-patch.yml
@@ -7,7 +7,7 @@ jobs:
         container:
             image: alpine:latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v2.3.4
             - run: apk add bash
             - run: bash qbittorrent-nox-static.sh
             - run: bash qbittorrent-nox-static.sh zlib

--- a/.github/workflows/swizzin.yml
+++ b/.github/workflows/swizzin.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - run: sudo apt-get update
       - run: sudo apt-get -y upgrade
       - run: sudo apt-get -y install python git curl


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.3.4](https://github.com/actions/checkout/releases/tag/v2.3.4) on 2020-11-03T14:48:49Z
