### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/matrix_cmake.yml
+++ b/.github/workflows/matrix_cmake.yml
@@ -131,7 +131,7 @@ jobs:
         run: mv -f "${{ env.build_dir }}/completed/qbittorrent_graph.png" "${{ env.build_dir }}/completed/qbittorrent_${{ matrix.name }}_graph.png"
       #
       - name: "Create release - tag - assets"
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.8.6
         with:
           prerelease: ${{ matrix.preview_release }}
           artifacts: "${{ env.build_dir }}/completed/qbittorrent-nox-${{ matrix.release_name }}"

--- a/.github/workflows/matrix_qmake.yml
+++ b/.github/workflows/matrix_qmake.yml
@@ -129,7 +129,7 @@ jobs:
         run: mv -f "${{ env.build_dir }}/completed/qbittorrent-nox" "${{ env.build_dir }}/completed/qbittorrent_nox_${{ matrix.release_name }}"
       #
       - name: "Create release - tag - assets"
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.8.6
         with:
           prerelease: ${{ matrix.preview_release }}
           artifacts: "${{ env.build_dir }}/completed/qbittorrent_nox_${{ matrix.release_name }}"

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Create tag env
         run: echo 'iperf_tag='$(strings ${{ env.iperf_path }} | grep -E '^iperf 3\.[0-9]{1,3}$' | awk '{print $2}') >> $GITHUB_ENV
       - name: "Create release"
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.8.6
         with:
           prerelease: false
           artifacts: "${{ env.iperf_path }}"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[ncipollo/release-action](https://github.com/ncipollo/release-action)** published a new release [v1.8.6](https://github.com/ncipollo/release-action/releases/tag/v1.8.6) on 2021-05-24T15:28:52Z
