### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/debian_based_CI.yml
+++ b/.github/workflows/debian_based_CI.yml
@@ -64,7 +64,7 @@ jobs:
       - run: bash qbittorrent-nox-static.sh qbittorrent ${{ matrix.build_tool_flag }}
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: ${{ env.artifact_name }}
           path: ${{ env.build_dir }}/completed/qbittorrent-nox

--- a/.github/workflows/matrix_multi_build_and_release.yml
+++ b/.github/workflows/matrix_multi_build_and_release.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Archive code coverage results
         if: env.qbt_build_tool == 'cmake'
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: ${{ env.name }}-graphs
           path: ${{ env.build_dir }}/completed/*.png

--- a/.github/workflows/matrix_multi_build_and_release_customs_tags.yml
+++ b/.github/workflows/matrix_multi_build_and_release_customs_tags.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Archive code coverage results
         if: env.qbt_build_tool == 'cmake'
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: ${{ env.name }}-graphs
           path: ${{ env.build_dir }}/completed/*.png

--- a/.github/workflows/multi_aarch64_artifacts - Copy.yml
+++ b/.github/workflows/multi_aarch64_artifacts - Copy.yml
@@ -70,7 +70,7 @@ jobs:
       - run: bash qbittorrent-nox-static.sh ${{ matrix.qbittorrent_patch }} qbittorrent
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: ${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.with_icu_name }}lt-v${{ matrix.libtorrent_version }}-qbittorrent-nox
           path: qbt-build/completed/qbittorrent-nox

--- a/.github/workflows/multi_aarch64_artifacts.yml
+++ b/.github/workflows/multi_aarch64_artifacts.yml
@@ -70,7 +70,7 @@ jobs:
       - run: bash qbittorrent-nox-static.sh ${{ matrix.qbittorrent_patch }} qbittorrent
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: ${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.with_icu_name }}lt-v${{ matrix.libtorrent_version }}-qbittorrent-nox
           path: qbt-build/completed/qbittorrent-nox

--- a/.github/workflows/multi_armhf_artifacts.yml
+++ b/.github/workflows/multi_armhf_artifacts.yml
@@ -70,7 +70,7 @@ jobs:
       - run: bash qbittorrent-nox-static.sh ${{ matrix.qbittorrent_patch }} qbittorrent
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: ${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.with_icu_name }}lt-v${{ matrix.libtorrent_version }}-qbittorrent-nox
           path: qbt-build/completed/qbittorrent-nox

--- a/.github/workflows/multi_armv7_artifacts.yml
+++ b/.github/workflows/multi_armv7_artifacts.yml
@@ -70,7 +70,7 @@ jobs:
       - run: bash qbittorrent-nox-static.sh ${{ matrix.qbittorrent_patch }} qbittorrent
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: ${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.with_icu_name }}lt-v${{ matrix.libtorrent_version }}-qbittorrent-nox
           path: qbt-build/completed/qbittorrent-nox

--- a/.github/workflows/multi_x86_64_artifacts.yml
+++ b/.github/workflows/multi_x86_64_artifacts.yml
@@ -70,7 +70,7 @@ jobs:
       - run: bash qbittorrent-nox-static.sh ${{ matrix.qbittorrent_patch }} qbittorrent
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: ${{ matrix.arch_type }}-${{ matrix.build_tool_name }}${{ matrix.with_icu_name }}lt-v${{ matrix.libtorrent_version }}-qbittorrent-nox
           path: qbt-build/completed/qbittorrent-nox

--- a/.github/workflows/qbittorrent_build_and_release.yml
+++ b/.github/workflows/qbittorrent_build_and_release.yml
@@ -248,7 +248,7 @@ jobs:
         run: mv -f "${{ matrix.name }}_${{ env.qbittorrent_version }}_${{ matrix.arch }}.deb" "${{ matrix.os_id }}-${{ matrix.os_version_id }}-${{ matrix.name }}-${{ matrix.arch }}.deb"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: "${{ matrix.os_id }}-${{ matrix.os_version_id }}-${{ matrix.name }}-${{ env.qbittorrent_version }}-libtorrent-${{ env.libtorrent_version }}-${{ matrix.arch }}"
           path: "${{ matrix.os_id }}-${{ matrix.os_version_id }}-${{ matrix.name }}-${{ matrix.arch }}.deb"

--- a/.github/workflows/qbittorrent_build_and_release_main - Copy.yml
+++ b/.github/workflows/qbittorrent_build_and_release_main - Copy.yml
@@ -131,7 +131,7 @@ jobs:
         run: mv -f "${{ matrix.name }}_${{ env.qbittorrent_version }}_${{ matrix.arch }}.deb" "${{ matrix.os_id }}-${{ matrix.os_version_id }}-${{ matrix.name }}-${{ matrix.arch }}.deb"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: "${{ matrix.os_id }}-${{ matrix.os_version_id }}-${{ matrix.name }}-${{ env.qbittorrent_version }}-libtorrent-${{ env.libtorrent_version }}-${{ matrix.arch }}"
           path: "${{ matrix.os_id }}-${{ matrix.os_version_id }}-${{ matrix.name }}-${{ matrix.arch }}.deb"

--- a/.github/workflows/qbittorrent_build_and_release_v3.yml
+++ b/.github/workflows/qbittorrent_build_and_release_v3.yml
@@ -131,7 +131,7 @@ jobs:
         run: mv -f "${{ matrix.name }}_${{ env.qbittorrent_version }}_${{ matrix.arch }}.deb" "${{ matrix.os_id }}-${{ matrix.os_version_id }}-${{ matrix.name }}-${{ matrix.arch }}.deb"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: "${{ matrix.os_id }}-${{ matrix.os_version_id }}-${{ matrix.name }}-${{ env.qbittorrent_version }}-libtorrent-${{ env.libtorrent_version }}-${{ matrix.arch }}"
           path: "${{ matrix.os_id }}-${{ matrix.os_version_id }}-${{ matrix.name }}-${{ matrix.arch }}.deb"

--- a/.github/workflows/qt6_RC_2_0_icu_amd64.yml
+++ b/.github/workflows/qt6_RC_2_0_icu_amd64.yml
@@ -33,7 +33,7 @@ jobs:
       - run: bash qbittorrent-nox-static.sh qbittorrent -qm
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: qbittorrent-nox
           path: qbt-build/completed/qbittorrent-nox


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release [v2.2.4](https://github.com/actions/upload-artifact/releases/tag/v2.2.4) on 2021-06-16T16:26:01Z
